### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,50 @@
-[ansible-lint](https://github.com/willthames/ansible-lint) to JUnit converter [![Build Status](https://travis-ci.org/wasilak/ansible-lint-junit.svg?branch=master)](https://travis-ci.org/wasilak/ansible-lint-junit)[![Total alerts](https://img.shields.io/lgtm/alerts/g/wasilak/ansible-lint-junit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wasilak/ansible-lint-junit/alerts/)[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wasilak/ansible-lint-junit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wasilak/ansible-lint-junit/context:python) [![Maintainability](https://api.codeclimate.com/v1/badges/e50acaa43b7a5f762904/maintainability)](https://codeclimate.com/github/wasilak/ansible-lint-junit/maintainability)
+[![Build Status](https://travis-ci.org/wasilak/ansible-lint-junit.svg?branch=master)](https://travis-ci.org/wasilak/ansible-lint-junit)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/wasilak/ansible-lint-junit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wasilak/ansible-lint-junit/alerts/)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wasilak/ansible-lint-junit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wasilak/ansible-lint-junit/context:python)
+[![Maintainability](https://api.codeclimate.com/v1/badges/e50acaa43b7a5f762904/maintainability)](https://codeclimate.com/github/wasilak/ansible-lint-junit/maintainability)
+
+Ansible-lint-junit
 ---
 
+The [ansible-lint](https://github.com/willthames/ansible-lint) to JUnit converter.
+
 ### Installation
-via pip;
+
+via pip:
+
 ```shell
 pip install ansible-lint-junit
 ```
 
 ### Updating
+
 via pip:
+
 ```shell
 pip install ansible-lint-junit --upgrade
 ```
 
 ### Usage:
-1. you can pipe output of `ansible-lint`:
-    ```shell
-    # less verbose
-    ansible-lint playbook.yml -p --nocolor | ansible-lint-junit -o ansible-lint.xml
 
-    # more verbose
-    ansible-lint playbook.yml --parseable-severity --nocolor | ansible-lint-junit -o ansible-lint.xml
-    ```
-3. or run `ansible-lint` on your playbook(s) and redirect output to file
-    ```shell
-    # less verbose
-    ansible-lint -p --nocolor your_fancy_playbook.yml > ansible-lint.txt
-
-    # more verbose
-    ansible-lint --parseable-severity --nocolor your_fancy_playbook.yml > ansible-lint.txt
-    ```
-    and run `ansible-lint-junit` and pass generated file to it
-    ```shell
-    # less verbose
-    ansible-lint-junit ansible-lint.txt -o ansible-lint.xml
-
-    # more verbose
-    ansible-lint-junit ansible-lint.txt -o ansible-lint.xml
-    ```
+- You can run `ansible-lint` on your playbook(s) and redirect output to pipe
+  ```shell
+  ansible-lint playbook.yml -p --nocolor | ansible-lint-junit -o ansible-lint.xml
+  ```
+- You can use a temporary file to store the output of `ansible-lint`.
+  After that run `ansible-lint-junit` and pass generated file to it
+  ```shell
+  ansible-lint -p --nocolor your_fancy_playbook.yml > ansible-lint.txt
+  ansible-lint-junit ansible-lint.txt -o ansible-lint.xml
+  ```
 
 ### Output
-* if there are any lint errors, full JUnit XML will be created
-* if there are no errors, empty JUnit XML will be created, this is for i.e. [Bamboo](https://www.atlassian.com/software/bamboo) JUnit parser plugin compatibility.
-It will break build if XML is missing or incorrect, and there is really no way of generating XML with *"PASSED"* tests in case of linter.
+
+- If there are any lint errors, full JUnit XML will be created.
+- If there are no errors, empty JUnit XML will be created, this is for
+  i.e. [Bamboo](https://www.atlassian.com/software/bamboo) JUnit parser plugin compatibility.\
+  It will break build if XML is missing or incorrect, and there is really no way of generating XML with *"PASSED"* tests
+  in case of linter.
+
+### License
+
+The ansible-lint-junit project is distributed under the [MIT] license.


### PR DESCRIPTION
## Summary
Reformat and fix some errors in README.md

## Details
1. Reformat beginning and move badges before the initial header like in the ansible/ansible-lint project.
1. Remove outdated ansible-lint call with --parseable-severity, because it was removed in ansible/ansible-lint#1898.
1. Reformat list of available calls to make look like there are several methods of calling ansible-lint-junit, not a list of consecutive actions.
1. Add information about project license.
1. Fix grammar and style.