### PR TITLE
Fix 'NoneType' object has no attribute 'group'

### DIFF
--- a/src/ansible_lint_junit/main.py
+++ b/src/ansible_lint_junit/main.py
@@ -55,6 +55,9 @@ def main():
             if 0 < len(line):
 
                 line_match = line_regex.match(line)
+                
+                if not line_match:
+                    continue
 
                 line_data = {
                     "filename": line_match.group(1),


### PR DESCRIPTION
When parsing ansible lint output there are sometimes places like this:
```
roles/base/luks/tasks/setup_luks.yml:27: jinja: Jinja2 spacing could be improved: if test -L /dev/mapper/{{ item.name }}
then
echo "== LUKS {{item.name}} activated == "
else
echo "== Enter LUKS for {{item.name}} pass =="
/sbin/cryptsetup luksOpen {{item.device}} {{item.name}} || exit 1
fi
sleep 7
 -> if test -L /dev/mapper/{{ item.name }}
then
echo "== LUKS {{ item.name }} activated == "
else
echo "== Enter LUKS for {{ item.name }} pass =="
/sbin/cryptsetup luksOpen {{ item.device }} {{ item.name }} || exit 1
fi
sleep 7
 (jinja[spacing])
```
So there are no matching lines to the pattern '^(.*?):(\\d+?):\\s(.*)$' 
And we fall with
```
Traceback (most recent call last):
  File "/Users/akurenyshev/PycharmProjects/drawNetwork/venv/bin/ansible-lint-junit", line 8, in <module>
    sys.exit(main())
  File "/Users/akurenyshev/PycharmProjects/drawNetwork/venv/lib/python3.8/site-packages/ansible_lint_junit/main.py", line 60, in main
    "filename": line_match.group(1),
AttributeError: 'NoneType' object has no attribute 'group'
```
Patch fixes this