### PR TITLE
Feature: Add option to ignore ansible-lint warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ $RECYCLE.BIN/
 
 ansible-lint-junit.xml
 output.txt
+
+bin/
+pyvenv.cfg

--- a/src/ansible_lint_junit/main.py
+++ b/src/ansible_lint_junit/main.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument('--version', action='version',
                         version='%(prog)s {version}'.format(version=version()))
     parser.add_argument("--ignore-warnings", action="store_true", default=False,
-                        help="Ignore warnings")
+                        help="Ignore ansible-lint warnings")
 
     arguments = parser.parse_args()
 
@@ -51,7 +51,7 @@ def main():
 
     for line in ansible_lint_output:
         if len(line):
-            errors_count = str(len(ansible_lint_output) - 1)
+            # Break ansible_lint_output is empty, I suppose?      
             break
 
     if arguments.dummy:
@@ -73,7 +73,6 @@ def main():
             parsed_lines = []
             for line in ansible_lint_output:
                 if 0 < len(line):
-                    #print(line)
                     line_match = line_regex.match(line)
 
                     if not line_match:
@@ -88,6 +87,7 @@ def main():
                         "text": line_match.group(3),
                     }
                     parsed_lines.append(line_data)
+                    errors_count = int(errors_count) + 1
 
                     testcase = ET.SubElement(
                         testsuite, "testcase", name="{}-{}".format(line_data['filename'], len(parsed_lines)))
@@ -100,6 +100,8 @@ def main():
                         message=line_data['error'],
                         type="Ansible Lint"
                     ).text = line_data['error']
+
+                    testsuite.set("errors", str(errors_count))
 
     xml_string = ET.tostring(testsuites, encoding='utf8', method='xml')
     xml_nice = minidom.parseString(xml_string)

--- a/src/ansible_lint_junit/main.py
+++ b/src/ansible_lint_junit/main.py
@@ -34,7 +34,7 @@ def main():
                         help="Adds single (1) dummy test if there were 0 tests and/or 0 errors", default=False)
     parser.add_argument('--version', action='version',
                         version='%(prog)s {version}'.format(version=version()))
-    parser.add_argument("--ignore-warnings", default=False,
+    parser.add_argument("--ignore-warnings", action="store_true", default=False,
                         help="Ignore warnings")
 
     arguments = parser.parse_args()
@@ -73,15 +73,14 @@ def main():
             parsed_lines = []
             for line in ansible_lint_output:
                 if 0 < len(line):
-
+                    #print(line)
                     line_match = line_regex.match(line)
 
                     if not line_match:
                         continue
 
-                    if arguments.ignore_warnings and "(warning)" in line_match.group(3).lower:
+                    if arguments.ignore_warnings and line_match.group(3).endswith(" (warning)"):
                         continue
-
                     line_data = {
                         "filename": line_match.group(1),
                         "line": int(line_match.group(2)),

--- a/src/ansible_lint_junit/main.py
+++ b/src/ansible_lint_junit/main.py
@@ -32,7 +32,7 @@ def main():
                         help="print XML to console as command output", default=False)
     parser.add_argument("-d", "--dummy-test", dest="dummy", action="store_true",
                         help="Adds single (1) dummy test if there were 0 tests and/or 0 errors", default=False)
-    parser.add_argument('--version', action='version',
+    parser.add_argument("--version", action="version",
                         version='%(prog)s {version}'.format(version=version()))
     parser.add_argument("--ignore-warnings", action="store_true", default=False,
                         help="Ignore ansible-lint warnings")

--- a/src/ansible_lint_junit/main.py
+++ b/src/ansible_lint_junit/main.py
@@ -34,7 +34,7 @@ def main():
                         help="Adds single (1) dummy test if there were 0 tests and/or 0 errors", default=False)
     parser.add_argument("--version", action="version",
                         version='%(prog)s {version}'.format(version=version()))
-    parser.add_argument("--ignore-warnings", action="store_true", default=False,
+    parser.add_argument("-w", "--ignore-warnings", action="store_true", default=False,
                         help="Ignore ansible-lint warnings")
 
     arguments = parser.parse_args()

--- a/src/ansible_lint_junit/main.py
+++ b/src/ansible_lint_junit/main.py
@@ -34,6 +34,8 @@ def main():
                         help="Adds single (1) dummy test if there were 0 tests and/or 0 errors", default=False)
     parser.add_argument('--version', action='version',
                         version='%(prog)s {version}'.format(version=version()))
+    parser.add_argument("--ignore-warnings", default=False,
+                        help="Ignore warnings")
 
     arguments = parser.parse_args()
 
@@ -75,6 +77,9 @@ def main():
                     line_match = line_regex.match(line)
 
                     if not line_match:
+                        continue
+
+                    if arguments.ignore_warnings and "(warning)" in line_match.group(3).lower:
                         continue
 
                     line_data = {


### PR DESCRIPTION
By demoting certain errors to warnings in `ansible-lint` (`-w`, [`warn_list:`](https://github.com/ansible/ansible-lint/blob/5934e343217e44291d37e0b780905934b6dc2710/.ansible-lint#L72)) I want to signify that I don't really care about those testcases.

AFAIK the behavior of `ansible-lint` [is to append a string to the end of the line](https://github.com/ansible/ansible-lint/blob/5934e343217e44291d37e0b780905934b6dc2710/src/ansiblelint/app.py#L318).

## Test case

This `output.txt`:

```
somedir/somefile.yaml:16: yaml[line-length]: Line too long (313 > 160 characters) (warning)
somedir/somefile.yaml:16:16: yaml[line-length]: Line too long (313 > 160 characters) (warning)
somedir/somefile.yaml:16:27: yaml[line-length]: Line too long (192 > 160 characters) (warning)
somedir/somefile.yaml:16:27: yaml[line-length]: Line too long (192 > 160 characters) (warning)
somedir/anotherfile.yaml:7: package-latest: Package installs should not use latest.
```

Should result in the following XML output:

```
<?xml version="1.0" ?>
<testsuites>
        <testsuite errors="1" failures="0" tests="0" time="0">
                <testcase name="somedir/anotherfile.yaml-1">
                        <failure file="somedir/anotherfile.yaml" line="7" message="package-latest: Package installs should not use latest." type="Ansible Lint">package-latest: Package installs should not use latest.</failure>
                </testcase>
        </testsuite>
</testsuites>
```


